### PR TITLE
Improved HTML generation

### DIFF
--- a/src/Vega.jl
+++ b/src/Vega.jl
@@ -11,9 +11,6 @@ module Vega
     export plot
     export barplot, lineplot, scatterplot, areaplot, heatmap
 
-    const VEGADIR = tempdir()
-    const HTMLPATH = joinpath(VEGADIR, "vega.jl.html")
-
     function install()
         initial = pwd()
         cd(Pkg.dir("Vega"))

--- a/src/primitives/visualization.jl
+++ b/src/primitives/visualization.jl
@@ -96,36 +96,46 @@ function tojson(v::VegaVisualization)
     JSON.json(Vega.tojs(v))
 end
 
-function tohtml(v::VegaVisualization)
+function writehtml(io::IO, v::VegaVisualization; title="Vega.jl Visualization")
+	js = tojs(v)
+
 	spec = tojson(v)
     d3path = Pkg.dir("Vega", "deps/vega/examples/lib/d3.v3.min.js")
     vegapath = Pkg.dir("Vega", "deps/vega/vega.js")
-    html = string("<html>
-  <head>
-    <title>Vega.jl Visualization</title/>
-    <script src='$d3path'></script>
-    <script src='$vegapath'></script>
-  </head>
-  <body>
-    <div style='text-align: center' id='view' class='view'></div>
-  </body>
-  <script type='text/javascript'>
-  spec = ", spec, ";",
-  "vg.parse.spec(spec, function(chart) {
-    self.view = chart({el:'#view'}).update();
-  });
-  </script>
-</html>")
-    return html
+
+    println(io, "<html>")
+
+    # print head
+    println(io, "<head>")
+    println(io, "  <title>$title</title>")
+    println(io, "  <script src='$d3path'></script>")
+    println(io, "  <script src='$vegapath'></script>")
+    println(io, "</head>")
+
+    # print body
+    println(io, "<body>x<div style='text-align: center' id='view' class='view'></div></body>")
+
+    # print script
+    println(io, "<script type='text/javascript'>")
+    print(io, "spec = ")
+    JSON.print(io, js)
+    println(io, ";")
+    println(io, "vg.parse.spec(spec, function(chart) {
+    	self.view = chart({el:'#view'}).update();
+  	});")
+    println(io, "</script>")
 end
 
+
 function Base.show(io::IO, v::VegaVisualization)
-    io = open(HTMLPATH, "w")
-    println(io, tohtml(v))
+	# create a temporary file 
+	tmppath = string(tempname(), ".vega.html")
+    io = open(tmppath, "w")
+    writehtml(io, v)
     close(io)
 
     # Open the browser
-    openurl(HTMLPATH)
+    openurl(tmppath)
 
     # Turn off clean up steps for now
     # rm(HTMLPATH)


### PR DESCRIPTION
- Previously, it used a fixed filename(), i.e. HTMLPATH, for all graphs. This may cause problems when generating multiple graphs at the same time. Now it uses tempname() to generate a filename, which results in different file paths for different plots.
- Previously, it used JSON.json to generate the entire spec string, and then embed it into an HTML string, and write that string to a file. This ways incurs the generation of huge string, which is unnecessary. The modified version directly uses JSON.print to write stuff to a file, thus eliminating those temporary strings in memory.
