### PR TITLE
change vega submodule url to public url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/vega"]
 	path = deps/vega
-	url = git@github.com:trifacta/vega.git
+	url = https://github.com/trifacta/vega.git


### PR DESCRIPTION
I think maybe this should be using the "public URL". 

Until I made this change locally, I got this error:

julia> Vega.install()
Cloning into 'deps/vega'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Clone of 'git@github.com:trifacta/vega.git' into submodule path 'deps/vega' failed
ERROR: failed process: Process(`git submodule update`, ProcessExited(1)) [1]
 in pipeline_error at process.jl:476
 in run at process.jl:453
 in install at /Users/david/.julia/Vega/src/Vega.jl:21