### PR TITLE
VEGA2: removed `data.` prefix from datarefs

### DIFF
--- a/src/derived/barplot.jl
+++ b/src/derived/barplot.jl
@@ -16,12 +16,12 @@
     add_rects!(v)
 
     v.marks[1].properties.enter.width = VegaValueRef(scale = "x", band = true, offset = -1)
-    v.marks[1].properties.enter.y2 = VegaValueRef(scale = "y", field = "data.y2")
-    v.marks[1].properties.enter.fill = VegaValueRef(scale = "group", field = "data.group")
+    v.marks[1].properties.enter.y2 = VegaValueRef(scale = "y", field = "y2")
+    v.marks[1].properties.enter.fill = VegaValueRef(scale = "group", field = "group")
 
     if stacked
       push!(v.data, VegaData(name = "stats", source = "table",
-                             transform = [VegaTransform(Dict{Any, Any}("type" => "facet", "keys" => ["data.x"])), VegaTransform(Dict{Any, Any}("type" => "stats", "value" => "data.y"))]))
+                             transform = [VegaTransform(Dict{Any, Any}("type" => "facet", "groupby" => ["x"])), VegaTransform(Dict{Any, Any}("type" => "stats", "value" => "y"))]))
 
       v.scales[2].domain = VegaDataRef("stats", "sum")
       v.scales[3].domain = nothing
@@ -30,16 +30,16 @@
       v.marks[1]._type = "group"
 
       v.marks[1].from = Dict{Any, Any}("data" => "table",
-                                       "transform" => [VegaTransform(Dict{Any, Any}("type" => "facet", "keys" => ["data.group"])), VegaTransform(Dict{Any, Any}("type" => "stack", "point" => "data.x", "height" => "data.y"))])
+                                       "transform" => [VegaTransform(Dict{Any, Any}("type" => "facet", "groupby" => ["group"])), VegaTransform(Dict{Any, Any}("type" => "stack", "point" => "x", "height" => "y"))])
 
       v.marks[1].marks = [
                           VegaMark(_type = "rect",
                           properties = VegaMarkProperties(
-                                                      enter = VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "data.x"),
+                                                      enter = VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "x"),
                                                                                   width = VegaValueRef(scale = "x", band = true, offset = -1),
                                                                                   y = VegaValueRef(scale = "y", field = "y"),
                                                                                   y2 = VegaValueRef(scale = "y", field = "y2"),
-                                                                                  fill = VegaValueRef(scale = "group", field = "data.group")
+                                                                                  fill = VegaValueRef(scale = "group", field = "group")
                                                                                   )
                                                           )
                                   )

--- a/src/derived/choropleth.jl
+++ b/src/derived/choropleth.jl
@@ -8,7 +8,7 @@
                             url = "http://trifacta.github.io/vega/data/us-10m.json",
                            format = VegaFormat(_type = "topojson", feature = "counties"),
                             transform = [VegaTransform(Dict{Any, Any}("type" => "geopath", "value" => "data", "projection" => "albersUsa")),
-        VegaTransform(Dict{Any, Any}("type" => "zip", "key" => "data.id", "with" => "table", "withKey" => "data.x", "as" => "value", "default" => nothing)),
+        VegaTransform(Dict{Any, Any}("type" => "zip", "key" => "id", "with" => "table", "withKey" => "x", "as" => "value", "default" => nothing)),
                                         VegaTransform(Dict{Any, Any}("type" => "filter", "test" => "d.path!=null && d.value!=null"))]
                           )
          )
@@ -22,7 +22,7 @@
     v.marks = [VegaMark(_type = "path",
                         from = Dict{Any, Any}("data" => "counties"),
                         properties = VegaMarkProperties(enter = VegaMarkPropertySet(path = VegaValueRef(field = "path")),
-                                                        update = VegaMarkPropertySet(fill = VegaValueRef(scale = "color", field = "value.data.y")),
+                                                        update = VegaMarkPropertySet(fill = VegaValueRef(scale = "color", field = "value.y")),
                                                         hover = VegaMarkPropertySet(fill = VegaValueRef(value = "red")))
             )]
 

--- a/src/derived/groupedbar.jl
+++ b/src/derived/groupedbar.jl
@@ -11,25 +11,25 @@
                             _type = "ordinal",
                             range = "width",
                             padding = 0.2,
-                            domain = VegaDataRef("table", "data.x"))
+                            domain = VegaDataRef("table", "x"))
     v.scales[2] = VegaScale(name = "y",
                             range = "height",
-                            domain = VegaDataRef("table", "data.y"),
+                            domain = VegaDataRef("table", "y"),
                             nice = true)
     v.scales[3] = VegaScale(name = "group",
                             _type = "ordinal",
                             range = "category20",
-                            domain = VegaDataRef("table", "data.group"))
+                            domain = VegaDataRef("table", "group"))
 
     v.marks = [VegaMark(_type = "group")]
     v.marks[1].from = Dict{Any, Any}("data" => "table",
-                                     "transform" => [VegaTransform(Dict{Any, Any}("keys" => ["data.x"], "type" => "facet"))])
+                                     "transform" => [VegaTransform(Dict{Any, Any}("groupby" => ["x"], "type" => "facet"))])
 
     v.marks[1].marks = [VegaMark(_type = "rect")]
-    v.marks[1].marks[1].properties = VegaMarkProperties(enter = VegaMarkPropertySet(fill = VegaValueRef(field = "data.group", scale = "group"),
+    v.marks[1].marks[1].properties = VegaMarkProperties(enter = VegaMarkPropertySet(fill = VegaValueRef(field = "group", scale = "group"),
                                                                                     width = VegaValueRef(band = true, offset = -1, scale = "pos"),
-                                                                                    x = VegaValueRef(field = "data.group", scale = "pos"),
-                                                                                    y = VegaValueRef(field = "data.y", scale = "y"),
+                                                                                    x = VegaValueRef(field = "group", scale = "pos"),
+                                                                                    y = VegaValueRef(field = "y", scale = "y"),
                                                                                     y2 = VegaValueRef(scale = "y", value = 0)
                                                                                     )
                                                         )
@@ -41,7 +41,7 @@
     v.marks[1].scales = [VegaScale(name = "pos",
                                     _type = "ordinal",
                                     range = "width",
-                                    domain = VegaDataRef("field", "data.group"))]
+                                    domain = VegaDataRef("field", "group"))]
 
     return v
 

--- a/src/derived/heatmap.jl
+++ b/src/derived/heatmap.jl
@@ -32,29 +32,29 @@
                           range = "width",
                           nice = true,
                           zero = false,
-                          domain = VegaDataRef("table", "data.x"))
+                          domain = VegaDataRef("table", "x"))
 
     v.scales[2] = VegaScale(name = "y",
                           _type = "linear",
                           range = "height",
                           nice = true,
                           zero = false,
-                          domain = VegaDataRef("table", "data.y"))
+                          domain = VegaDataRef("table", "y"))
 
     v.scales[3] = VegaScale(name = "group",
                           _type = "ordinal",
                           range = "category20",
-                          domain = VegaDataRef("table", "data.group"))
+                          domain = VegaDataRef("table", "group"))
 
     v.marks = Array(VegaMark, 1)
     enterprops =
       VegaMarkPropertySet(shape = VegaValueRef(value = "square"), # May need to be "string"
                           x = VegaValueRef(scale = "x",
-                                           field = "data.x"),
+                                           field = "x"),
                           y = VegaValueRef(scale = "y",
-                                           field = "data.y"),
+                                           field = "y"),
                           fill = VegaValueRef(scale = "group",
-                                              field = "data.group"))
+                                              field = "group"))
     v.marks[1] = VegaMark(_type = "symbol",
                         from = Dict{Any, Any}("data" => "table"),
                         properties = VegaMarkProperties(enter = enterprops))

--- a/src/derived/lineplot.jl
+++ b/src/derived/lineplot.jl
@@ -10,7 +10,7 @@ function lineplot(;x::AbstractVector = Int[],
     add_data!(v, x = x, y = y, group = group)
     add_lines!(v)
 
-    v.marks[1].marks[1].properties.enter.stroke = VegaValueRef(scale = "group", field = "data.group")
+    v.marks[1].marks[1].properties.enter.stroke = VegaValueRef(scale = "group", field="group")
 
     return v
 end

--- a/src/derived/piechart.jl
+++ b/src/derived/piechart.jl
@@ -6,15 +6,15 @@
     add_data!(v, x = x, y = y)
 
     v.scales = [VegaScale(name = "color",
-                      domain = VegaDataRef("table", "data.x"),
+                      domain = VegaDataRef("table", "x"),
                       range = "category10",
                       _type = "ordinal")]
 
     v.marks = [VegaMark(_type = "arc",
-                       from = Dict{Any, Any}("data"=> "table", "transform"=> [Dict{Any, Any}("type"=> "pie", "value"=> "data.y")]),
+                       from = Dict{Any, Any}("data"=> "table", "transform"=> [Dict{Any, Any}("type"=> "pie", "value"=> "y")]),
                        properties = VegaMarkProperties(enter = VegaMarkPropertySet(
                                                                                    endAngle = VegaValueRef(field = "endAngle"),
-                                                                                   fill = VegaValueRef(field = "data.x", scale = "color"),
+                                                                                   fill = VegaValueRef(field = "x", scale = "color"),
                                                                                    innerRadius = VegaValueRef(value = holesize),
                                                                                    outerRadius = VegaValueRef(value = 250),
                                                                                    startAngle = VegaValueRef(field = "startAngle"),

--- a/src/derived/popchart.jl
+++ b/src/derived/popchart.jl
@@ -5,7 +5,7 @@
 
     v.scales = Array(VegaScale, 3)
     v.scales[1] = VegaScale(name = "g", domain = [0,1], range = [340, 10])
-    v.scales[2] = VegaScale(name = "y", _type = "ordinal", range = "height", reverse = true, domain = VegaDataRef("table", "data.y"))
+    v.scales[2] = VegaScale(name = "y", _type = "ordinal", range = "height", reverse = true, domain = VegaDataRef("table", "y"))
     v.scales[3] = VegaScale(name = "group", _type = "ordinal", domain = [1,2], range = ["#1f77b4", "#e377c2"])
 
     v.marks = Array(VegaMark,2)
@@ -13,7 +13,7 @@
     v.marks[1] = VegaMark(
     _type = "text",
     from = Dict{Any, Any}("data" => "table",
-                          "transform" => [Dict{Any, Any}("type" => "unique",  "field" => "data.y", "as" => "y")]
+                          "transform" => [Dict{Any, Any}("type" => "unique",  "field" => "y", "as" => "y")]
                          ),
     properties = VegaMarkProperties(
     enter = VegaMarkPropertySet(
@@ -30,9 +30,9 @@
     _type = "group",
     from = Dict{Any, Any}(
             "data" => "table",
-    "transform" => [Dict{Any, Any}("type" => "facet", "keys" => ["data.group"])]),
+    "transform" => [Dict{Any, Any}("type" => "facet", "groupby" => ["group"])]),
     properties = VegaMarkProperties(update = VegaMarkPropertySet(
-                                                                x = VegaValueRef(scale = "g", field = "index"),
+                                                                x = VegaValueRef(scale = "g", field = "_id"),
                                                                 y = VegaValueRef(value = 0),
                                                                 width = VegaValueRef(value = 300),
                                                                 height = VegaValueRef(group = "height")
@@ -42,9 +42,9 @@
         name = "x",
         _type = "linear",
         range = "width",
-        reverse = VegaDataRef(field = "index"),
+        reverse = VegaDataRef(field = "_id"),
         nice = true,
-        domain = VegaDataRef(data = "table", field = "data.x")
+        domain = VegaDataRef(data = "table", field = "x")
         )
 
     ],
@@ -52,12 +52,12 @@
 
     marks = [VegaMark(
     _type = "rect",
-    properties = VegaMarkProperties(enter = VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "data.x"),
+    properties = VegaMarkProperties(enter = VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "x"),
                                                                     x2 = VegaValueRef(scale = "x", value = 0),
-                                                                    y = VegaValueRef(scale = "y", field = "data.y"),
+                                                                    y = VegaValueRef(scale = "y", field = "y"),
                                                                     height = VegaValueRef(scale = "y", band = true, offset = -1),
                                                                     fillOpacity = VegaValueRef(value = 0.6),
-                                                                    fill = VegaValueRef(scale = "group", field = "data.group")
+                                                                    fill = VegaValueRef(scale = "group", field = "group")
 
 
         )

--- a/src/derived/scatterplot.jl
+++ b/src/derived/scatterplot.jl
@@ -10,7 +10,7 @@
     add_data!(v, x = x, y = y, group = group)
     add_points!(v)
 
-    v.marks[1].properties.enter.fill = VegaValueRef(scale = "group", field = "data.group")
+    v.marks[1].properties.enter.fill = VegaValueRef(scale = "group", field = "group")
     v.marks[1].properties.enter.fillOpacity = VegaValueRef(value = 0.5)
 
     return v

--- a/src/derived/waterfall.jl
+++ b/src/derived/waterfall.jl
@@ -26,7 +26,7 @@
     #Clean-up presentation
     v.width = 110 * length(x) #Make the graph variable width based on number of levels
     v.marks[1].properties.enter.width = VegaValueRef(scale = "x", band = true, mult= 0.5)
-    v.marks[1].properties.enter.x  = VegaValueRef(scale = "x", field = "data.x", offset = 31)
+    v.marks[1].properties.enter.x  = VegaValueRef(scale = "x", field = "x", offset = 31)
 
     xlab!(v, "")
     ylab!(v, "")

--- a/src/derived/wordcloud.jl
+++ b/src/derived/wordcloud.jl
@@ -3,8 +3,8 @@
 
     add_data!(v, x = x, y = y)
 
-    v.data[1].transform = [VegaTransform(Dict{Any, Any}("type" => "wordcloud", "text" => "data.x", "font" => "Helvetica Neue",
-        "fontSize" => "data.y", "rotate" => Dict{Any, Any}("random" => [-60,-30,0,30,60])))]
+    v.data[1].transform = [VegaTransform(Dict{Any, Any}("type" => "wordcloud", "text" => "x", "font" => "Helvetica Neue",
+        "fontSize" => "y", "rotate" => Dict{Any, Any}("random" => [-60,-30,0,30,60])))]
 
     v.marks = Array(VegaMark,1)
     v.marks[1] = VegaMark(_type = "text",
@@ -17,7 +17,7 @@
                                                                     baseline = VegaValueRef(value = "alphabetic"),
                                                                     font = VegaValueRef(field = "font"),
                                                                     fontSize = VegaValueRef(field = "fontSize"),
-                                                                    text = VegaValueRef(field = "data.x")
+                                                                    text = VegaValueRef(field = "x")
                                                                     ),
 
                                                          update = VegaMarkPropertySet(fill = VegaValueRef(value = "steelblue")),

--- a/src/intermediates/defaults.jl
+++ b/src/intermediates/defaults.jl
@@ -4,15 +4,15 @@
     v.scales[1] = VegaScale(name = "x",
                             _type = "linear",
                             range = "width",
-                            domain = VegaDataRef("table", "data.x"))
+                            domain = VegaDataRef("table", "x"))
     v.scales[2] = VegaScale(name = "y",
                             _type = "linear",
                             range = "height",
-                            domain = VegaDataRef("table", "data.y"))
+                            domain = VegaDataRef("table", "y"))
     v.scales[3] = VegaScale(name = "group",
                             _type = "ordinal",
                             range = "category10",
-                            domain = VegaDataRef("table", "data.group"))
+                            domain = VegaDataRef("table", "group"))
 
     return v
 end

--- a/src/intermediates/lines.jl
+++ b/src/intermediates/lines.jl
@@ -7,7 +7,7 @@
                    from = Dict{Any, Any}(
                            "data" => "table",
                            "transform" =>
-                             [Dict{Any, Any}("type" => "facet", "keys" => ["data.group"])]
+                             [Dict{Any, Any}("type" => "facet", "groupby" => ["group"])]
                           ),
                    marks = innermarks)
 

--- a/src/intermediates/modifiers.jl
+++ b/src/intermediates/modifiers.jl
@@ -65,16 +65,16 @@ end
 
     #No group marks
     if typeof(v.marks[1].marks) in (Nothing, Void)
-        v.marks[1].properties.enter.y = VegaValueRef(scale = "x", field = "data.x")
+        v.marks[1].properties.enter.y = VegaValueRef(scale = "x", field = "x")
         v.marks[1].properties.enter.height = VegaValueRef(scale = "x", band = true, offset = -1)
-        v.marks[1].properties.enter.x = VegaValueRef(scale = "y", field = "data.y")
+        v.marks[1].properties.enter.x = VegaValueRef(scale = "y", field = "y")
         v.marks[1].properties.enter.x2 = VegaValueRef(scale = "y", value = 0)
         v.marks[1].properties.enter.y2 = nothing
     #Group Marks
     else
-        v.marks[1].marks[1].properties.enter.y = VegaValueRef(scale = "x", field = "data.x")
+        v.marks[1].marks[1].properties.enter.y = VegaValueRef(scale = "x", field = "x")
         v.marks[1].marks[1].properties.enter.height = VegaValueRef(scale = "x", band = true, offset = -1)
-        v.marks[1].marks[1].properties.enter.x = VegaValueRef(scale = "y", field = "data.y")
+        v.marks[1].marks[1].properties.enter.x = VegaValueRef(scale = "y", field = "y")
         v.marks[1].marks[1].properties.enter.x2 = VegaValueRef(scale = "y", value = 0)
         v.marks[1].marks[1].properties.enter.y2 = nothing
     end

--- a/src/intermediates/props.jl
+++ b/src/intermediates/props.jl
@@ -1,6 +1,6 @@
 function default_props()
     return VegaMarkPropertySet(x = VegaValueRef(scale = "x",
-                                                field = "data.x"),
+                                                field = "x"),
                                y = VegaValueRef(scale = "y",
-                                                field = "data.y"))
+                                                field = "y"))
 end

--- a/src/render.jl
+++ b/src/render.jl
@@ -65,7 +65,7 @@ function writehtml(io::IO, v::VegaVisualization; title="Vega.jl Visualization")
     println(io," <script src=\"http://trifacta.github.io/vega/lib/d3.v3.min.js\"></script>")
     println(io," <script src=\"http://trifacta.github.io/vega/lib/d3.geo.projection.min.js\"></script>")
     println(io," <script src=\"http://trifacta.github.io/vega/lib/topojson.js\"></script>")
-    println(io," <script src=\"http://trifacta.github.io/vega/vega.js\"></script>")
+    println(io," <script src=\"http://vega.github.io/vega/vega.js\"></script>")
     println(io, "</head>")
 
     # print body

--- a/test/valueref.jl
+++ b/test/valueref.jl
@@ -2,7 +2,7 @@
 @assert Vega.tojs(VegaValueRef(value = 5)) == Dict("value" => 5)
 
 # The value of data.price, for the current datum
-@assert Vega.tojs(VegaValueRef(field = "data.price")) == Dict("field" => "data.price")
+@assert Vega.tojs(VegaValueRef(field = "price")) == Dict("field" => "price")
 
 # The value of index for the current datum, multiplied by 20
 @assert Vega.tojs(VegaValueRef(field = "index", mult = 20)) == Dict("field" => "index", "mult" => 20)
@@ -11,7 +11,7 @@
 @assert Vega.tojs(VegaValueRef(scale = "x", value = 0)) == Dict("scale" => "x", "value" => 0)
 
 # The result of running data.price for the current datum through the scale named y
-@assert Vega.tojs(VegaValueRef(scale = "y", field = "data.price")) == Dict("scale" => "y", "field" => "data.price")
+@assert Vega.tojs(VegaValueRef(scale = "y", field = "price")) == Dict("scale" => "y", "field" => "price")
 
 # The range band width of the ordinal scale x. Note that the scale must be ordinal!
 @assert Vega.tojs(VegaValueRef(scale = "x", band = true)) == Dict("scale" => "x", "band" => true)

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -6,19 +6,19 @@ d = [VegaData(values = [Dict{Any, Any}("x" => 1, "y" => 1),
 s = [VegaScale(name = "x",
                _type = "ordinal",
                range = "width",
-               domain = VegaDataRef("table", "data.x"))
+               domain = VegaDataRef("table", "x"))
        VegaScale(name = "y",
                  _type = "linear",
                  range = "height",
-                 domain = VegaDataRef("table", "data.y"))]
+                 domain = VegaDataRef("table", "y"))]
 
 m = [VegaMark(_type = "rect",
     from = Dict{Any, Any}("data" => "table"),
               properties =
                 VegaMarkProperties(enter =
-                  VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "data.x"),
+                  VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "x"),
                                       width = VegaValueRef(scale = "x", band = true, offset = -1),
-                                      y = VegaValueRef(scale = "y", field = "data.y"),
+                                      y = VegaValueRef(scale = "y", field = "y"),
                                       y2 = VegaValueRef(scale = "y", value = 0)),
                  update = VegaMarkPropertySet(fill = VegaValueRef(value = "steelblue")),
                  hover = VegaMarkPropertySet(fill = VegaValueRef(value = "red"))))]


### PR DESCRIPTION
also changed `keys` to `groupby` in the facet transform for adding colors