### PR TITLE
ENH: fixed area, stackedarea, pie, donut for vega2

### DIFF
--- a/src/Vega.jl
+++ b/src/Vega.jl
@@ -32,6 +32,7 @@ module Vega
     include("primitives/data.jl")
     include("primitives/markpropertyset.jl")
     include("primitives/markproperties.jl")
+    include("primitives/markfrom.jl")
     include("primitives/scale.jl")
     include("primitives/mark.jl")
     include("primitives/legend.jl")

--- a/src/derived/areaplot.jl
+++ b/src/derived/areaplot.jl
@@ -3,22 +3,32 @@
                    group::AbstractVector = Int[],
                    stacked::Bool = false)
 
-    v = barplot(x = x, y = y, group = group)
-
-    v.marks[1]._type = "area"
-    v.marks[1].properties.enter.width = nothing
-    v.marks[1].properties.enter.interpolate = VegaValueRef(value = "monotone")
-    v.scales[1]._type = nothing
-    v.scales[1].zero = false
-
     if stacked
     	v = barplot(x = x, y = y, group = group, stacked = true)
-	    v.scales[1].zero = false
-		  v.scales[1]._type = nothing
-		  v.marks[1].marks[1]._type = "area"
-		  v.marks[1].marks[1].properties.enter.interpolate = VegaValueRef(value = "monotone")
-		  v.marks[1].marks[1].properties.enter.width = nothing
-	  end
+	    v.scales[1].points = true
+		v.scales[1]._type = nothing
+
+        innermark = VegaMark(_type="area", properties=VegaMarkProperties(enter = default_props()))
+        innermark.properties.enter.y = VegaValueRef(scale = "y", field = "layout_start")
+        innermark.properties.enter.y2 = VegaValueRef(scale = "y", field = "layout_end")
+        innermark.properties.enter.fill = VegaValueRef(scale = "group", field = "group")
+        innermark.properties.enter.interpolate = VegaValueRef(value="monotone")
+
+        mark = VegaMark(_type = "group",
+                        from = VegaMarkFrom(data="table",
+                                            transform=[VegaTransform(Dict{Any,Any}("type"=>"stack", "groupby" => ["x"], "sortby" => ["group"], "field" => "y")),
+                                                       VegaTransform(Dict{Any,Any}("type"=>"facet", "groupby" => ["group"]))]),
+                        marks = [innermark])
+        v.marks = [mark]
+	else
+        v = barplot(x = x, y = y, group = group)
+
+        v.marks[1]._type = "area"
+        v.marks[1].properties.enter.width = nothing
+        v.marks[1].properties.enter.interpolate = VegaValueRef(value = "monotone")
+        v.scales[1]._type = "linear"
+        v.scales[1].zero = false
+    end
 
     return v
 end

--- a/src/derived/barplot.jl
+++ b/src/derived/barplot.jl
@@ -30,8 +30,8 @@
 
       v.scales[2].domain = VegaDataRef("stats", "sum_y")
 
-      v.marks[1].from = Dict{Any, Any}("data" => "table",
-                                       "transform" => [VegaTransform(Dict{Any, Any}("type" => "stack", "groupby" => ["x"], "sortby" => ["group"], "field"=>"y"))])
+      v.marks[1].from = VegaMarkFrom(data = "table",
+                                     transform = [VegaTransform(Dict{Any, Any}("type" => "stack", "groupby" => ["x"], "sortby" => ["group"], "field"=>"y"))])
     end
 
     #Return horizontal bar chart

--- a/src/derived/choropleth.jl
+++ b/src/derived/choropleth.jl
@@ -20,7 +20,7 @@
                         )]
 
     v.marks = [VegaMark(_type = "path",
-                        from = Dict{Any, Any}("data" => "counties"),
+                        from = VegaMarkFrom(data="counties"),
                         properties = VegaMarkProperties(enter = VegaMarkPropertySet(path = VegaValueRef(field = "path")),
                                                         update = VegaMarkPropertySet(fill = VegaValueRef(scale = "color", field = "value.y")),
                                                         hover = VegaMarkPropertySet(fill = VegaValueRef(value = "red")))

--- a/src/derived/groupedbar.jl
+++ b/src/derived/groupedbar.jl
@@ -22,8 +22,8 @@
                             domain = VegaDataRef("table", "group"))
 
     v.marks = [VegaMark(_type = "group")]
-    v.marks[1].from = Dict{Any, Any}("data" => "table",
-                                     "transform" => [VegaTransform(Dict{Any, Any}("groupby" => ["x"], "type" => "facet"))])
+    v.marks[1].from = VegaMarkFrom(data = "table",
+                                   transform = [VegaTransform(Dict{Any, Any}("groupby" => ["x"], "type" => "facet"))])
 
     v.marks[1].marks = [VegaMark(_type = "rect")]
     v.marks[1].marks[1].properties = VegaMarkProperties(enter = VegaMarkPropertySet(fill = VegaValueRef(field = "group", scale = "group"),

--- a/src/derived/heatmap.jl
+++ b/src/derived/heatmap.jl
@@ -56,7 +56,7 @@
                           fill = VegaValueRef(scale = "group",
                                               field = "group"))
     v.marks[1] = VegaMark(_type = "symbol",
-                        from = Dict{Any, Any}("data" => "table"),
+                        from = VegaMarkFrom(data="table"),
                         properties = VegaMarkProperties(enter = enterprops))
 
     return v

--- a/src/derived/piechart.jl
+++ b/src/derived/piechart.jl
@@ -11,13 +11,14 @@
                       _type = "ordinal")]
 
     v.marks = [VegaMark(_type = "arc",
-                       from = Dict{Any, Any}("data"=> "table", "transform"=> [Dict{Any, Any}("type"=> "pie", "value"=> "y")]),
+                       from = VegaMarkFrom(data = "table",
+                                           transform = [VegaTransform(Dict{Any, Any}("type"=> "pie", "value"=> "y"))]),
                        properties = VegaMarkProperties(enter = VegaMarkPropertySet(
-                                                                                   endAngle = VegaValueRef(field = "endAngle"),
+                                                                                   endAngle = VegaValueRef(field = "layout_end"),
                                                                                    fill = VegaValueRef(field = "x", scale = "color"),
                                                                                    innerRadius = VegaValueRef(value = holesize),
                                                                                    outerRadius = VegaValueRef(value = 250),
-                                                                                   startAngle = VegaValueRef(field = "startAngle"),
+                                                                                   startAngle = VegaValueRef(field = "layout_start"),
                                                                                    stroke = VegaValueRef(value = "white"),
                                                                                    x = VegaValueRef(group = "width", mult = 0.5),
                                                                                    y = VegaValueRef(group = "height", mult = 0.5)

--- a/src/derived/popchart.jl
+++ b/src/derived/popchart.jl
@@ -12,9 +12,8 @@
 
     v.marks[1] = VegaMark(
     _type = "text",
-    from = Dict{Any, Any}("data" => "table",
-                          "transform" => [Dict{Any, Any}("type" => "unique",  "field" => "y", "as" => "y")]
-                         ),
+    from = VegaMarkFrom(data = "table",
+                        transform = [VegaTransform(Dict{Any, Any}("type" => "unique",  "field" => "y", "as" => "y"))]),
     properties = VegaMarkProperties(
     enter = VegaMarkPropertySet(
     x = VegaValueRef(value = 325),
@@ -28,9 +27,8 @@
 
     v.marks[2] = VegaMark(
     _type = "group",
-    from = Dict{Any, Any}(
-            "data" => "table",
-    "transform" => [Dict{Any, Any}("type" => "facet", "groupby" => ["group"])]),
+    from = VegaMarkFrom(data = "table",
+                        transform = [VegaTransform(Dict{Any, Any}("type" => "facet", "groupby" => ["group"]))]),
     properties = VegaMarkProperties(update = VegaMarkPropertySet(
                                                                 x = VegaValueRef(scale = "g", field = "_id"),
                                                                 y = VegaValueRef(value = 0),

--- a/src/derived/wordcloud.jl
+++ b/src/derived/wordcloud.jl
@@ -8,7 +8,7 @@
 
     v.marks = Array(VegaMark,1)
     v.marks[1] = VegaMark(_type = "text",
-                          from = Dict{Any, Any}("data" => "table"),
+                          from = VegaMarkFrom(data="table"),
                           properties = VegaMarkProperties(enter = VegaMarkPropertySet(
                                                                     x = VegaValueRef(field = "x"),
                                                                     y = VegaValueRef(field = "y"),

--- a/src/intermediates/area.jl
+++ b/src/intermediates/area.jl
@@ -1,6 +1,6 @@
 function add_area!(v::VegaVisualization)
     res = VegaMark(_type = "area",
-                   from = Dict{Any, Any}("data" => "table"),
+                   from = VegaMarkFrom(data="table"),
                    properties = VegaMarkProperties(enter = default_props()))
 
     if v.marks == nothing

--- a/src/intermediates/lines.jl
+++ b/src/intermediates/lines.jl
@@ -4,11 +4,9 @@
       VegaMark(_type = "line",
                properties = VegaMarkProperties(enter = default_props()))
     res = VegaMark(_type = "group",
-                   from = Dict{Any, Any}(
-                           "data" => "table",
-                           "transform" =>
-                             [Dict{Any, Any}("type" => "facet", "groupby" => ["group"])]
-                          ),
+                   from = VegaMarkFrom(data = "table",
+                                       transform =[VegaTransform(Dict{Any, Any}("type" => "facet", "groupby" => ["group"]))]
+                                       ),
                    marks = innermarks)
 
     if v.marks == nothing

--- a/src/intermediates/modifiers.jl
+++ b/src/intermediates/modifiers.jl
@@ -25,19 +25,7 @@ end
 end
 
 @compat function title!(v::VegaVisualization, title::String)
-	titlemark = VegaMark()
-	titlemark.type = "text"
-	titlemark.from = Dict{Any, Any}("value" => title)
-    enterprops = VegaMarkPropertySet(x = VegaValueRef(value = v.width / 2),
-                                     y = VegaValueRef(value = 0),
-                                     text = VegaValueRef(value = title))
-	titlemark.properties = VegaMarkProperties(enter = enterprops)
-	push!(v.marks, titlemark)
-	return v
-end
-
-@compat function title!(v::VegaVisualization, title::String)
-	titlemark = VegaMark(_type = "text", from = Dict{Any, Any}("value" => title))
+	titlemark = VegaMark(_type = "text", from = VegaMarkFrom(value = title))
     enterprops = VegaMarkPropertySet(x = VegaValueRef(value = v.width / 2),
                                      y = VegaValueRef(value = -50),
                                      text = VegaValueRef(value = title),

--- a/src/intermediates/points.jl
+++ b/src/intermediates/points.jl
@@ -1,6 +1,6 @@
 @compat function add_points!(v::VegaVisualization)
     res = VegaMark(_type = "symbol",
-                   from = Dict{Any, Any}("data" => "table"),
+                   from = VegaMarkFrom(data="table"),
                    properties = VegaMarkProperties(enter = default_props()))
 
     if v.marks == nothing

--- a/src/intermediates/rects.jl
+++ b/src/intermediates/rects.jl
@@ -1,6 +1,6 @@
 function add_rects!(v::VegaVisualization)
     res = @compat VegaMark(_type = "rect",
-                   from = Dict{Any, Any}("data" => "table"),
+                   from = VegaMarkFrom(data="table"),
                    properties = VegaMarkProperties(enter = default_props()))
 
     if v.marks == nothing

--- a/src/primitives/data.jl
+++ b/src/primitives/data.jl
@@ -6,6 +6,7 @@ data_spec =
 	(:source, String, nothing),
 	(:url, String, nothing),
 	(:transform, Vector{VegaTransform}, nothing)
+    # TODO: (:modify, Vector{VegaStreamingOps}, nothing)
 ]
 
 primitivefactory(:VegaData, data_spec)

--- a/src/primitives/markfrom.jl
+++ b/src/primitives/markfrom.jl
@@ -1,0 +1,8 @@
+markfrom_spec =
+[
+    (:data, String, nothing),
+    (:transform, Vector{VegaTransform}, nothing),
+    (:value, String, nothing)
+]
+
+primitivefactory(:VegaMarkFrom, markfrom_spec)

--- a/src/primitives/scale.jl
+++ b/src/primitives/scale.jl
@@ -12,7 +12,7 @@ scale_spec =
 	(:round, Bool, nothing),
 	(:points, Bool, nothing),
 	(:padding, Number, nothing),
-	(:sort, Bool, nothing),
+	(:sort, Bool, nothing),  # TODO: docs say sort should be object
 	(:clamp, Bool, nothing),
 	(:nice, Bool, nothing),
 	(:exponent, Number, nothing),

--- a/src/primitives/valueref.jl
+++ b/src/primitives/valueref.jl
@@ -1,5 +1,7 @@
 valueref_spec =
 [
+    # TODO: field can also be an `Object` (`Dict{Any,Any}`)
+    # TODO: scale can also be an `Object` (`Dict{Any,Any}`)
 	(:value, Any, nothing),
 	(:field, String, nothing),
 	(:group, Union(String, Bool), nothing),

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -13,7 +13,7 @@ s = [VegaScale(name = "x",
                  domain = VegaDataRef("table", "y"))]
 
 m = [VegaMark(_type = "rect",
-    from = Dict{Any, Any}("data" => "table"),
+    from = VegaMarkFrom(data="table"),
               properties =
                 VegaMarkProperties(enter =
                   VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "x"),


### PR DESCRIPTION
Added a new type to represent the from field on the mark.

As I applied this change to the library I fixed various visualizations like area, stacked area, pie, donut...

The visualizations that still aren't working after this are

- choropleth
- groupedbar
- popchart
- wordcloud