### PR TITLE
Add palette to colorscheme! docs

### DIFF
--- a/areaplot.md
+++ b/areaplot.md
@@ -39,7 +39,7 @@ y = [28, 43, 81, 19, 52, 24, 87, 17, 68, 49, 55, 91, 53, 87, 48, 49, 66, 27, 16,
 g = [0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1]
 
 a = areaplot(x = x, y = y, group = g, stacked = true)
-colorscheme!(a, ("Reds", 3))
+colorscheme!(a, palette = ("Reds", 3))
 {% endhighlight %}
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/stackedarea.png" alt="stackedarea">
 

--- a/barplot.md
+++ b/barplot.md
@@ -65,7 +65,7 @@ y = [28, 43, 81, 19, 52, 24, 87, 17, 68, 49, 55, 91, 53, 87, 48, 49, 66, 27, 16,
 g = [0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1]
 
 b = barplot(x = x, y = y, group = g, stacked = true)
-colorscheme!(b, ("Greens", 3))
+colorscheme!(b, palette = ("Greens", 3))
 {% endhighlight %}
 
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/stackedbar.png" alt = "stackedbar">
@@ -79,7 +79,7 @@ y = [28, 43, 81, 19, 52, 24, 87, 17, 68, 49, 55, 91, 53, 87, 48, 49, 66, 27, 16,
 g = [0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1]
 
 b = barplot(x = x, y = y, group = g, stacked = true, horizontal = true)
-colorscheme!(b, ("Greens", 3))
+colorscheme!(b, palette = ("Greens", 3))
 {% endhighlight %}
 
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/stackedbarh.png" alt = "stackedbarh">

--- a/colorscheme.md
+++ b/colorscheme.md
@@ -25,7 +25,7 @@ This function mutates `:VegaVisualization`, modifying the colors for the `group`
 using Vega
 
 ab = barplot(x = [1:20], y = rand(20), group = vcat([1 for i in 1:10], [2 for i in 1:10]))
-colorscheme!(ab, ("Purples", 3))
+colorscheme!(ab, palette = ("Purples", 3))
 {% endhighlight %}
 
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/barcolorbrewerpurple.png" alt = "barcolorbrewerpurple">
@@ -37,7 +37,7 @@ using Vega
 
 srand(1)
 a = barplot(x = [1:20], y = rand(20))
-colorscheme!(a, "Violet")
+colorscheme!(a, palette = "Violet")
 {% endhighlight %}
 
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/barviolet.png" alt = "barviolet">
@@ -59,7 +59,7 @@ y = pop1900[:age]
 group = pop1900[:sex]
 
 pc1 = popchart(x = x, y = y, group = group)
-colorscheme!(pc1, ["Green", "Red"])
+colorscheme!(pc1, palette = ["Green", "Red"])
 {% endhighlight %}
 
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/bararray.png" alt = "bararray">

--- a/groupedbar.md
+++ b/groupedbar.md
@@ -26,7 +26,7 @@ position = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
 value = [0.1, 0.6, 0.9, 0.4, 0.7, 0.2, 1.1, 0.8, 0.6, 0.2, 0.1, 0.7]
 
 gb = groupedbar(x = category, y = value, position = position)
-colorscheme!(gb, ("Spectral", 5))
+colorscheme!(gb, palette = ("Spectral", 5))
 {% endhighlight %}
 
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/groupedbar.png" alt = "groupedbar">

--- a/wordcloud.md
+++ b/wordcloud.md
@@ -24,7 +24,7 @@ corpus = [
 ]
 
 wc = wordcloud(x = corpus)
-colorscheme!(wc, ("Spectral", 11))
+colorscheme!(wc, palette = ("Spectral", 11))
 {% endhighlight %}
 <img src ="http://johnmyleswhite.github.io/Vega.jl/images/wordcloud.png" alt="wordcloud">
 


### PR DESCRIPTION
Addresses #66 to some amount. I've fixed the uses of `colorscheme!` by adding the keyword `palette`. The keyword documentation has to be done specifically in `colorscheme.md` but I think I'll leave that to you. 

Also sorry about the newline removals. My editor keeps doing that.