### PR TITLE
Fix Heatmap Width

### DIFF
--- a/src/derived/heatmap.jl
+++ b/src/derived/heatmap.jl
@@ -31,7 +31,7 @@ function heatmap(;
     v.marks[1] = VegaMark(_type = "rect",
                           from = VegaMarkFrom(data = table),
                           properties = VegaMarkProperties(enter = VegaMarkPropertySet(x = VegaValueRef(scale = "x", field = "x"),
-                                                                                      width = VegaValueRef(value = 26),
+                                                                                      width = VegaValueRef(scale = "x", band = true),
                                                                                       y = VegaValueRef(scale = "y", field = "y"),
                                                                                       height = VegaValueRef(scale = "y", band = true),
                                                                                       fill = VegaValueRef(scale = "group", field = "group")


### PR DESCRIPTION
This code:

    using Vega
    N = 6
    heat = [rand() for i in 1:N, j in 1:N] |> vec
    x = [i for i in 1:N, j in 1:N] |> vec
    y = [j for i in 1:N, j in 1:N] |> vec
    heatmap(x=y, y=x, color=heat)

was producing weird thin vertical bands before this change (see below). I have close to no idea what the code is doing, but I copied it from the `height = ...` a couple of lines below, and it seems to work.

Cheers for your efforts - good package!

![mutant bar chart heatmap](https://cloud.githubusercontent.com/assets/854183/12054698/38e784dc-af2e-11e5-80a5-3e84c53508b8.png)
