### PR TITLE
WIP: First stab at getting Interact to work in IJulia

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ JSON
 ColorBrewer
 KernelDensity
 NoveltyColors
+Patchwork

--- a/src/render.jl
+++ b/src/render.jl
@@ -25,25 +25,19 @@ function writemime(io::IO, ::MIME"text/html", v::VegaVisualization)
     """)
 end
 
-isinstalled(pkg) = Pkg.installed(pkg) != nothing
+import Patchwork: Elem
 
-# writemime for signals of Plots
-if isinstalled("Patchwork")
-    import Patchwork: Elem
+function patchwork_repr(v::VegaVisualization)
+    divid = "vg" * randstring(3)
+    script_contents = scriptstr(v, divid)
+    Elem(:div, [
+        Elem(:div, "") & Dict(:id=>divid),
+        Elem(:script, script_contents) & Dict(:type=>"text/javascript")
+    ])
+end
 
-    function patchwork_repr(v::VegaVisualization)
-        divid = "vg" * randstring(3)
-        script_contents = scriptstr(v, divid)
-        Elem(:div, [
-            Elem(:div, "") & [:id=>divid],
-            Elem(:script, script_contents) & [:type=>"text/javascript"]
-        ])
-    end
-
-    function writemime(io::IO, m::MIME"text/html", v::VegaVisualization)
-        writemime(io, m, patchwork_repr(v))
-    end
-
+function writemime(io::IO, m::MIME"text/html", v::VegaVisualization)
+    writemime(io, m, patchwork_repr(v))
 end
 
 function scriptstr(v::VegaVisualization, divid)


### PR DESCRIPTION
I saw that Vega works with Escher. Doesn't seem to work for me with interact in an IJulia/Jupyter notebook:

    using Interact
    using Vega
    @manipulate for n in 1:10
        x = 0:n
        y = [binomial(n, k) for k = x]
        barplot(x=x, y=y)
    end

All I've done really in this PR is just get the writemime to output a [Patchwork](https://github.com/shashi/Patchwork.jl) node instead of the raw html. No idea if that's the right way to do it but it seems to work. Haven't tested on a machine without Patchwork installed.

Also, just remembered I'm actually on older versions of Interact (0.2.1) and Reactive (0.2.4) (since Gadfly wouldn't work with them for me with later versions. Aside - Gadfly v0.4.0 and Compose v0.4.0 work with those versions of Interact/Reactive, but not on other combinations of versions for me)