### PR TITLE
Change Position to Group in groupedbar

### DIFF
--- a/src/derived/groupedbar.jl
+++ b/src/derived/groupedbar.jl
@@ -1,4 +1,4 @@
-function groupedbar(; x::AbstractVector = Int[], y::AbstractVector = Int[], position::Vector{Int} = Int[], horizontal::Bool = false)
+function groupedbar(; x::AbstractVector = Int[], y::AbstractVector = Int[], group::AbstractVector = Int[], horizontal::Bool = false)
 
     v = VegaVisualization(height = 300, width = 500, name = "groupedbar")
 
@@ -7,7 +7,7 @@ function groupedbar(; x::AbstractVector = Int[], y::AbstractVector = Int[], posi
         x = UTF8String[string(s) for s in x]
     end
 
-    add_data!(v, x = x, y = y, group = position)
+    add_data!(v, x = x, y = y, group = group)
     default_axes!(v)
     legend!(v)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,9 +141,9 @@ a = choropleth(x = x, y = y, entity = :usstates)
 #15. Grouped Bar
 println("Test 15")
 category = ["A", "A", "A", "A", "B", "B", "B", "B", "C", "C", "C", "C"]
-position = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
+group = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
 value = [0.1, 0.6, 0.9, 0.4, 0.7, 0.2, 1.1, 0.8, 0.6, 0.2, 0.1, 0.7]
-a = groupedbar(x = category, y = value, position = position);
+a = groupedbar(x = category, y = value, group = group);
 
 @test typeof(a) == VegaVisualization
 #@test jsonschema.validate(tojs(a), vegaschema) == nothing
@@ -426,9 +426,9 @@ legend!(a, title = "Fruit")
 #41 stroke!
 println("Test 41")
 category = ['A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', 'C', 'C', 'C', 'C']
-position = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
+group = [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
 value = [0.1, 0.6, 0.9, 0.4, 0.7, 0.2, 1.1, 0.8, 0.6, 0.2, 0.1, 0.7]
-a = groupedbar(x = category, y = value, position = position);
+a = groupedbar(x = category, y = value, group = group);
 stroke!(a, width = 1.5)
 
 @test typeof(a) == VegaVisualization


### PR DESCRIPTION
Also allow non-Int groups. Minor change, works (for me) and makes it more consistent with other pre-defined plots.

Need to also make the following update to the `groupedbar` page in the docs:
(In the Function Keywords)
~~position::Vector{Int}~~
group::AbstractVector

(In the example code)
~~position = ...~~
group = ...

~~gb = groupedbar(x = category, y = value, position = position)~~
gb = groupedbar(x = category, y = value, group = group)