### PR TITLE
Improving heatmap

### DIFF
--- a/src/derived/heatmap.jl
+++ b/src/derived/heatmap.jl
@@ -15,15 +15,16 @@ function heatmap(;
     v.scales[2]._type = "ordinal"
 
     v.scales[3]._type = "linear"
-    v.scales[3].domain = [0,0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
     v.scales[3].range = ["#313695", "#4575b4", "#74add1", "#abd9e9", "#e0f3f8", "#ffffbf", "#fee090", "#fdae61", "#f46d43", "#d73027", "#a50026"]
+    cmin,cmax = extrema(color)
+    v.scales[3].domain = collect(linspace(cmin,cmax,length(v.scales[3].range)))
 
     #Use defaults for axes
     default_axes!(v)
 
     #Use default legend
     legend!(v)
-    v.legends[1].values = [0, 0.5, 1]
+    v.legends[1].values = [cmin, cmax]
     v.legends[1].title = ""
 
     #Marks


### PR DESCRIPTION
I'd like to use the heatmap functionality of this library, but looks like it could use some improvement. For starters, the color scale defaults to `[0,1]` but should probably be matched to the `[min,max]` of the input.

Before:

![download 2](https://cloud.githubusercontent.com/assets/636625/14540502/3173cb8e-023a-11e6-853d-75deae9769b8.png)

After:

![download 1](https://cloud.githubusercontent.com/assets/636625/14540493/2600e4ee-023a-11e6-8ada-97385d9be5b6.png)

This PR fixes that problem. Although, I'm a bit confused why:

```julia
domain = collect(linspace(cmin,cmax,length(v.scales[3].range)))
```

Is necessary... Why not `domain = [cmin,cmax]`? When I tried this, it only showed the first two colors on the color palette.

If my help is welcome, I'd be happy to add some more improvements. (Either in this PR, or open new ones.) For example, a function that replicates matplotlib's `imshow` function would be nice, and I have some simple code to do this. Also see a problem I'm having with the axes here: https://github.com/johnmyleswhite/Vega.jl/issues/125